### PR TITLE
fixed "undefined" when using third party libraries

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var {
 
 var formatUI5Module = (umdCode, mName) => `sap.ui.define(function(){
   ${umdCode}
-  return this.${mName}
+  return window.${mName}
 })
 `;
 


### PR DESCRIPTION
When using the "generator-ui5g" npm package and importing third party NPM libraries, the import in JSX comes up as "undefined".

I've noticed that in the "formatUI5Module" method we're returning:
```javascript
return this.${mName}
```
but instead we should be returning:
```javascript
return window.${mName}
```